### PR TITLE
Bump React and React-DOM to 19.2.1

### DIFF
--- a/src/Garage.Web/package-lock.json
+++ b/src/Garage.Web/package-lock.json
@@ -26,7 +26,7 @@
         "@opentelemetry/sdk-trace-web": "^2.2.0",
         "@opentelemetry/semantic-conventions": "^1.38.0",
         "react": "^19.2.1",
-        "react-dom": "^19.2.0"
+        "react-dom": "^19.2.1"
       },
       "devDependencies": {
         "@types/node": "^24.10.1",
@@ -3358,15 +3358,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
-      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
+      "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.0"
+        "react": "^19.2.1"
       }
     },
     "node_modules/react-refresh": {

--- a/src/Garage.Web/package.json
+++ b/src/Garage.Web/package.json
@@ -29,7 +29,7 @@
     "@opentelemetry/sdk-trace-web": "^2.2.0",
     "@opentelemetry/semantic-conventions": "^1.38.0",
     "react": "^19.2.1",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.1"
   },
   "devDependencies": {
     "@types/node": "^24.10.1",


### PR DESCRIPTION
Update React and React-DOM dependencies to the latest patch version for improved stability and performance. This change addresses minor issues and ensures compatibility with the latest features.