### PR TITLE
Bump dependencies for TypeScript and Vite

### DIFF
--- a/src/Garage.Web/package-lock.json
+++ b/src/Garage.Web/package-lock.json
@@ -33,7 +33,7 @@
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@typescript-eslint/eslint-plugin": "^8.50.0",
-        "@typescript-eslint/parser": "^8.49.0",
+        "@typescript-eslint/parser": "^8.50.0",
         "@vitejs/plugin-react": "^5.1.2",
         "eslint": "^9.39.2",
         "eslint-plugin-react-hooks": "^7.0.1",

--- a/src/Garage.Web/package.json
+++ b/src/Garage.Web/package.json
@@ -36,7 +36,7 @@
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@typescript-eslint/eslint-plugin": "^8.50.0",
-    "@typescript-eslint/parser": "^8.49.0",
+    "@typescript-eslint/parser": "^8.50.0",
     "@vitejs/plugin-react": "^5.1.2",
     "eslint": "^9.39.2",
     "eslint-plugin-react-hooks": "^7.0.1",


### PR DESCRIPTION
Update `@typescript-eslint/parser`, `@typescript-eslint/eslint-plugin`, and `vite` to their latest versions to ensure compatibility and access to new features.