### PR TITLE
Bump OpenTelemetry dependencies to latest versions

### DIFF
--- a/src/Garage.Web/package-lock.json
+++ b/src/Garage.Web/package-lock.json
@@ -19,7 +19,7 @@
         "@opentelemetry/instrumentation": "^0.209.0",
         "@opentelemetry/instrumentation-document-load": "^0.54.0",
         "@opentelemetry/instrumentation-fetch": "^0.209.0",
-        "@opentelemetry/resources": "^2.2.0",
+        "@opentelemetry/resources": "^2.3.0",
         "@opentelemetry/sdk-logs": "^0.209.0",
         "@opentelemetry/sdk-metrics": "^2.3.0",
         "@opentelemetry/sdk-trace-base": "^2.3.0",

--- a/src/Garage.Web/package.json
+++ b/src/Garage.Web/package.json
@@ -22,7 +22,7 @@
     "@opentelemetry/instrumentation": "^0.209.0",
     "@opentelemetry/instrumentation-document-load": "^0.54.0",
     "@opentelemetry/instrumentation-fetch": "^0.209.0",
-    "@opentelemetry/resources": "^2.2.0",
+    "@opentelemetry/resources": "^2.3.0",
     "@opentelemetry/sdk-logs": "^0.209.0",
     "@opentelemetry/sdk-metrics": "^2.3.0",
     "@opentelemetry/sdk-trace-base": "^2.3.0",


### PR DESCRIPTION
Update various OpenTelemetry packages to their latest minor versions to ensure compatibility and access to new features and improvements. This includes updates to tracing, logging, metrics, and instrumentation packages.