### PR TITLE
Refactor devcontainer configuration and add Dockerfile for base setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+# Remove Yarn apt repository with expired GPG key
+RUN rm -f /etc/apt/sources.list.d/yarn.list || true

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,15 +1,22 @@
 {
   "name": "OpenFeature Aspire Sample",
-  "image": "mcr.microsoft.com/devcontainers/dotnet:10.0",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
   "features": {
     "ghcr.io/devcontainers/features/github-cli:latest": {},
-    "ghcr.io/devcontainers/features/docker-in-docker": {},
-    "ghcr.io/devcontainers/features/node": {},
-    "ghcr.io/devcontainers/features/go": {},
+    "ghcr.io/devcontainers/features/dotnet:2": {
+      "version": "10.0"
+    },
+    "ghcr.io/devcontainers/features/node": {
+      "installYarnUsingApt": false
+    },
     "ghcr.io/devcontainers/features/python": {
       "version": "3.12"
     },
-    "ghcr.io/dotnet/aspire-devcontainer-feature/dotnetaspire:latest": {}
+    "ghcr.io/devcontainers/features/go": {},
+    "ghcr.io/dotnet/aspire-devcontainer-feature/dotnetaspire:latest": {},
+    "ghcr.io/devcontainers/features/docker-in-docker": {}
   },
   "customizations": {
     "vscode": {


### PR DESCRIPTION
Refactor the devcontainer configuration to utilize a custom Dockerfile for the base setup, ensuring a cleaner environment and removing unnecessary dependencies.