### PR TITLE
Add exclude-paths for GitHub Actions in dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    exclude-paths:
+      - .github/workflows/*.lock.yml
 
   - package-ecosystem: "npm"
     directory: "src/Garage.Web/"


### PR DESCRIPTION
Introduce `exclude-paths` to the Dependabot configuration to prevent updates for specific workflow lock files.