### PR TITLE
Optimize CI workflow for dotnet format and Node.js setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Build with dotnet
         run: dotnet build --configuration Release
       - name: dotnet format
-        run: dotnet format --verify-no-changes
+        run: dotnet format --verify-no-changes --no-restore
     #   - name: Test with dotnet
     #     run: dotnet test
 
@@ -157,7 +157,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: 'npm'


### PR DESCRIPTION
Skip redundant NuGet restore during the dotnet format step and add a version comment for the setup-node action for consistency.