### PR TITLE
Add .github/mcp.json for Copilot CLI MCP servers

### DIFF
--- a/.github/mcp.json
+++ b/.github/mcp.json
@@ -1,0 +1,39 @@
+{
+  "mcpServers": {
+    "aspire": {
+      "type": "local",
+      "command": "aspire",
+      "args": [
+        "agent",
+        "mcp"
+      ],
+      "tools": [
+        "*"
+      ]
+    },
+    "github-agentic-workflows": {
+      "type": "local",
+      "command": "gh",
+      "args": [
+        "aw",
+        "mcp-server"
+      ],
+      "tools": [
+        "*"
+      ]
+    },
+    "azure": {
+      "type": "local",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@azure/mcp@latest",
+        "server",
+        "start"
+      ],
+      "tools": [
+        "*"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Copilot CLI removed its (incomplete) support for reading `.vscode/mcp.json`, so the MCP servers this repo ships were no longer picked up when working from the CLI. VS Code still reads only `.vscode/mcp.json`, so the fix is to add a parallel config in a location the CLI supports rather than move the existing one.

This adds `.github/mcp.json` using the Copilot CLI schema (`mcpServers`, `type: "local"`, `tools`), mirroring the three servers already configured for VS Code.

A few deliberate differences from the VS Code file:

- `github-agentic-workflows` drops `cwd: "${workspaceFolder}"`. That is a VS Code-only variable and the CLI has no expansion for it. The CLI already launches servers from the workspace root, so the behaviour is unchanged.
- `"Azure MCP Server"` is renamed to `azure`. Spaces in a server name make CLI usage awkward (`copilot mcp get "Azure MCP Server"`, comma-separated tool filters).
- The VS Code-only `"inputs": []` key is dropped.
- `type` is `local` rather than `stdio`, matching what the CLI itself writes.

`.vscode/mcp.json` is intentionally left untouched so VS Code users are unaffected. The trade-off is two files that can drift; worth flagging in review if you would rather standardise on one editor config.

Verified locally:

- `copilot mcp list` lists all three under **Workspace servers**
- `copilot mcp get <name>` resolves each one's source to `.github/mcp.json`
- `aspire agent mcp` and `gh aw mcp-server` both complete an MCP handshake from the repo root without `cwd`