### PR TITLE
Migrate the chatbot from GitHub Models to Microsoft Foundry

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,13 +8,13 @@ This repository is set up to use Aspire. Aspire is an orchestrator for the entir
 ### Technology Stack
 
 - **.NET**: 10.0 (latest version)
-- **Python**: 3.12+ (for Chat Service with GitHub Models)
+- **Python**: 3.14+ (for Chat Service with Microsoft Foundry)
 - **Go**: 1.25 (for Feature Flags API)
 - **Frontend**: React 19.2 with TypeScript, Vite 7.2
 - **Backend**: ASP.NET Core 10.0 with Entity Framework Core
 - **Orchestration**: .NET Aspire 13.0
 - **Feature Flags**: OpenFeature with OFREP and flagd provider
-- **AI/Chat**: GitHub Models (GPT-4o) with GitHub Repository Prompts
+- **AI/Chat**: Microsoft Foundry (Phi-4-mini) with GitHub Repository Prompts
 - **Database**: PostgreSQL with Entity Framework Core
 - **Caching**: Redis via StackExchange.Redis
 - **Telemetry**: OpenTelemetry integration (traces, metrics, logs)
@@ -193,7 +193,7 @@ The chatbot uses GitHub Repository Prompts format for dynamic prompt selection:
 # prompts/expert.prompt.yml
 name: Le Mans Expert
 description: A knowledgeable Le Mans racing historian
-model: openai/gpt-4o
+model: microsoft/phi-4-mini
 modelParameters:
   temperature: 0.7
 messages:
@@ -252,7 +252,7 @@ Currently, there are no test projects in the solution. When adding tests:
 - Keep .NET SDK at version 10.0.100 or later (see `global.json`)
 - Review and update NuGet, npm, and uv-managed Python packages regularly
 - Follow security best practices for feature flag configuration
-- Store GitHub PAT as user secret for GitHub Models access
+- Install Foundry Local so the chat model can run on-device during development
 
 ## Documentation
 
@@ -307,7 +307,9 @@ Currently, there are no test projects in the solution. When adding tests:
   - Reads/writes to the flagd.json configuration file
 - The Python Chat Service (`Garage.ChatService`) provides AI-powered chatbot
   - Uses FastAPI with Uvicorn (ASGI)
-  - Integrates with GitHub Models (GPT-4o) for AI responses
+  - Integrates with Microsoft Foundry (Phi-4-mini) for AI responses via the OpenAI-compatible API
+  - Foundry Local in run mode (`CHAT_MODEL_KEY` is injected), Azure AI Foundry in publish mode (Entra ID via `DefaultAzureCredential`)
+  - Reads `CHAT_MODEL_URI`, `CHAT_MODEL_API_PATH`, `CHAT_MODEL_KEY`, and `CHAT_MODEL_MODELNAME` from Aspire
   - Uses OpenFeature OFREP provider for feature flags
   - Supports GitHub Repository Prompts (`.prompt.yml`) for dynamic prompt selection
   - Includes full OpenTelemetry instrumentation (traces, metrics, logs via OTLP gRPC)

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,8 +16,8 @@
     <PackageVersion Include="Aspire.Hosting.Browsers" Version="13.4.6-preview.1.26319.6" />
     <PackageVersion Include="Aspire.Hosting.DevTunnels" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.EntityFrameworkCore" Version="13.4.6-preview.1.26319.6" />
+    <PackageVersion Include="Aspire.Hosting.Foundry" Version="13.4.6-preview.1.26319.6" />
     <PackageVersion Include="Aspire.Hosting.Go" Version="13.4.6-preview.1.26319.6" />
-    <PackageVersion Include="Aspire.Hosting.GitHub.Models" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.JavaScript" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.Python" Version="13.4.6" />
     <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.4.6" />

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This demo showcases how to implement feature flags using **OpenFeature** and the
 - **Dynamic Configuration**: Real-time feature flag updates without redeployment
 - **Full-Stack Implementation**: Feature flags working seamlessly across React UI, .NET API, and Python services
 - **Kill Switches**: Safely toggle features in production environments
-- **GitHub Models Integration**: AI-powered chatbot using GPT-4o via GitHub Models
+- **Microsoft Foundry Integration**: AI-powered chatbot using Phi-4-mini, served by Foundry Local during development and Azure AI Foundry when deployed
 - **GitHub Repository Prompts**: Dynamic prompt selection using `.prompt.yml` files
 
 ## Architecture
@@ -30,7 +30,7 @@ This demo showcases how to implement feature flags using **OpenFeature** and the
 - **Garage.ApiService**: REST API for car data with Entity Framework Core
 - **Garage.ApiModel**: Data model library containing the EF Core DbContext and entity definitions
 - **Garage.ApiDatabaseSeeder**: Database migration and seeding service
-- **Garage.ChatService**: Python FastAPI service for AI chatbot using GitHub Models
+- **Garage.ChatService**: Python FastAPI service for AI chatbot using Microsoft Foundry
 - **Garage.FeatureFlags**: Go API for managing feature flag targeting rules
 - **Garage.ServiceDefaults**: Shared services including OpenFeature, OpenTelemetry, and resilience configuration
 - **Garage.Shared**: Common models, DTOs, and seed data
@@ -41,7 +41,7 @@ This demo showcases how to implement feature flags using **OpenFeature** and the
 - **PostgreSQL**: Database for storing car collection data
 - **Redis**: Caching layer for improved performance
 - **flagd**: OpenFeature-compliant feature flag evaluation engine
-- **GitHub Models**: AI model provider for chatbot functionality
+- **Microsoft Foundry**: AI model provider for chatbot functionality (Foundry Local when running, Azure AI Foundry when published)
 - **Dev Tunnels**: Secure tunneling for external access to flagd during development
 
 ## Telemetry Support
@@ -90,7 +90,7 @@ The chatbot supports multiple prompt styles via GitHub Repository Prompts (`.pro
 - Git for version control
 - Docker Desktop (for containerized dependencies)
 - Azure account (for Dev Tunnels authentication during development)
-- GitHub PAT with access to GitHub Models (for chatbot functionality)
+- [Foundry Local](https://learn.microsoft.com/azure/ai-foundry/foundry-local/get-started) (for chatbot functionality)
 
 ## Quick Start
 
@@ -101,12 +101,21 @@ git clone https://github.com/open-feature/openfeature-aspire-sample.git
 cd openfeature-aspire-sample
 ```
 
-### 2. Configure GitHub Token (for Chatbot)
+### 2. Install Foundry Local (for Chatbot)
+
+The chatbot runs the Phi-4-mini model on your machine through [Foundry Local](https://learn.microsoft.com/azure/ai-foundry/foundry-local/get-started). Aspire starts the service and downloads the model for you, but the CLI has to be installed first:
 
 ```bash
-cd src/Garage.AppHost
-dotnet user-secrets set "Parameters:github-token" "<your-github-pat>"
+# macOS
+brew tap microsoft/foundrylocal
+brew trust microsoft/foundrylocal
+brew install foundrylocal
+
+# Windows
+winget install Microsoft.FoundryLocal
 ```
+
+> **Note:** The first run downloads the model weights, so it takes a few minutes. The dev container does not ship Foundry Local — run the app on the host if you need the chatbot. When the app is published, this resource becomes a provisioned Azure AI Foundry account instead, and the chat service authenticates with its managed identity.
 
 ### 3. Restore Dependencies
 
@@ -185,7 +194,7 @@ PUT  /flags/{name}    # Update targeting rules for a flag
 The Python chat service (`Garage.ChatService`) provides an AI-powered chatbot for Le Mans racing questions:
 
 - **Framework**: FastAPI with Uvicorn
-- **AI Provider**: GitHub Models (GPT-4o)
+- **AI Provider**: Microsoft Foundry (Phi-4-mini)
 - **Feature Flags**: OpenFeature with OFREP provider
 - **Telemetry**: Full OpenTelemetry integration (traces, metrics, logs)
 - **Prompts**: GitHub Repository Prompts format (`.prompt.yml`)
@@ -207,7 +216,8 @@ Response: { "status": "healthy" }
 - [OFREP Specification](https://openfeature.dev/specification/ofrep)
 - [flagd Documentation](https://flagd.dev/)
 - [.NET Aspire Documentation](https://learn.microsoft.com/en-us/dotnet/aspire/)
-- [GitHub Models Documentation](https://docs.github.com/en/github-models)
+- [Microsoft Foundry Documentation](https://learn.microsoft.com/azure/ai-foundry/)
+- [Foundry Local Documentation](https://learn.microsoft.com/azure/ai-foundry/foundry-local/)
 - [GitHub Repository Prompts](https://docs.github.com/en/github-models/use-github-models/storing-prompts-in-github-repositories)
 - [Feature Flag Best Practices](https://martinfowler.com/articles/feature-toggles.html)
 

--- a/src/Garage.AppHost/Garage.AppHost.csproj
+++ b/src/Garage.AppHost/Garage.AppHost.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="Aspire.Hosting.Browsers" />
     <PackageReference Include="Aspire.Hosting.DevTunnels" />
     <PackageReference Include="Aspire.Hosting.EntityFrameworkCore" />
+    <PackageReference Include="Aspire.Hosting.Foundry" />
     <PackageReference Include="Aspire.Hosting.Go" />
-    <PackageReference Include="Aspire.Hosting.GitHub.Models" />
     <PackageReference Include="Aspire.Hosting.JavaScript" />
     <PackageReference Include="Aspire.Hosting.Python" />
     <PackageReference Include="CommunityToolkit.Aspire.Hosting.Flagd" />

--- a/src/Garage.AppHost/Program.cs
+++ b/src/Garage.AppHost/Program.cs
@@ -1,5 +1,6 @@
-using Aspire.Hosting.GitHub;
+using Aspire.Hosting.Foundry;
 using Azure.Provisioning;
+using Azure.Provisioning.CognitiveServices;
 using Azure.Provisioning.Expressions;
 using Azure.Provisioning.Resources;
 using Azure.Provisioning.Roles;
@@ -12,11 +13,17 @@ var builder = DistributedApplication.CreateBuilder(args);
 var containerAppEnvironment = builder
     .AddAzureContainerAppEnvironment("cae");
 
-// Add GitHub Models (requires GitHub PAT)
-var githubToken = builder.AddParameter("github-token", secret: true);
-var chatModel = builder.AddGitHubModel("chat-model", GitHubModel.OpenAI.OpenAIGpt4o)
-    .WithApiKey(githubToken)
-    .WithHealthCheck();
+// Microsoft Foundry provides the chat model: Foundry Local on the developer machine,
+// a provisioned Azure AI Foundry account when published.
+var foundry = builder.AddFoundry("foundry")
+    .RunAsFoundryLocal();
+
+// Foundry Local only serves on-device models, so the Phi-4 descriptor differs per mode
+// even though both resolve to the same model family. Phi-4-mini keeps the chatbot responsive
+// on developer machines without a dedicated GPU.
+var chatModel = foundry.AddDeployment(
+    "chat-model",
+    builder.ExecutionContext.IsPublishMode ? FoundryModel.Microsoft.Phi4MiniInstruct : FoundryModel.Local.Phi4Mini);
 
 var cache = builder.AddAzureManagedRedis("cache").RunAsContainer();
 
@@ -42,6 +49,7 @@ var chatService = builder.AddUvicornApp("chatservice", "../Garage.ChatService/",
     .WithUv()
     .WithExternalHttpEndpoints()
     .WithReference(chatModel)
+    .WaitFor(chatModel)
     .WithEnvironment("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "true")
     .WithOtlpExporter()
     .WithHttpHealthCheck("/health")
@@ -49,8 +57,14 @@ var chatService = builder.AddUvicornApp("chatservice", "../Garage.ChatService/",
 
 if (builder.ExecutionContext.IsPublishMode)
 {
+    // Foundry Local publishes a ready-to-use OpenAI base URL, but Azure AI Foundry only exposes the
+    // account root, so the OpenAI-compatible route has to be appended there.
+    // Azure AI Foundry also has local auth disabled, so the chat service authenticates with its
+    // managed identity instead of an API key.
     chatService = chatService
-        .WithArgs("main:app", "--host", "0.0.0.0", "--port", "8000");
+        .WithArgs("main:app", "--host", "0.0.0.0", "--port", "8000")
+        .WithEnvironment("CHAT_MODEL_API_PATH", "openai/v1")
+        .WithRoleAssignments(foundry, CognitiveServicesBuiltInRole.CognitiveServicesUser);
 }
 
 // Feature flags infrastructure

--- a/src/Garage.ChatService/main.py
+++ b/src/Garage.ChatService/main.py
@@ -1,4 +1,4 @@
-"""Le Mans Chatbot Service - FastAPI application using GitHub Models and OpenFeature."""
+"""Le Mans Chatbot Service - FastAPI application using Microsoft Foundry and OpenFeature."""
 
 import os
 import time
@@ -7,12 +7,14 @@ import json
 from typing import Any
 from contextlib import asynccontextmanager
 from pathlib import Path
+from urllib.parse import urlsplit
 
 import grpc
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from openai import OpenAI
 from openfeature import api
 from openfeature.contrib.provider.ofrep import OFREPProvider
@@ -47,10 +49,19 @@ from prompt_loader import load_prompt, render_messages, get_model_parameters
 
 # Get configuration from environment
 OFREP_ENDPOINT = os.environ.get("OFREP_ENDPOINT", "http://localhost:8016")
-# GitHub Models connection from Aspire (uses format: {RESOURCE}_{PROPERTY})
-GITHUB_MODELS_ENDPOINT = os.environ.get("CHAT_MODEL_URI", "https://models.github.ai/inference")
-GITHUB_TOKEN = os.environ.get("CHAT_MODEL_KEY", "")
-GITHUB_MODEL_NAME = os.environ.get("CHAT_MODEL_MODELNAME", "openai/gpt-4o")
+# Microsoft Foundry connection from Aspire (uses format: {RESOURCE}_{PROPERTY}).
+# Foundry Local injects CHAT_MODEL_KEY; Azure AI Foundry does not and expects a
+# Microsoft Entra ID token from the service's managed identity instead.
+CHAT_MODEL_ENDPOINT = os.environ.get("CHAT_MODEL_URI", "http://localhost:5273/v1")
+# Foundry Local already exposes a complete OpenAI base URL, while Azure AI Foundry only exposes the
+# account root, so the AppHost supplies the extra "openai/v1" segment in publish mode.
+CHAT_MODEL_API_PATH = os.environ.get("CHAT_MODEL_API_PATH", "")
+CHAT_MODEL_KEY = os.environ.get("CHAT_MODEL_KEY", "")
+CHAT_MODEL_NAME = os.environ.get("CHAT_MODEL_MODELNAME", "phi-4-mini")
+CHAT_MODEL_SCOPE = os.environ.get("CHAT_MODEL_SCOPE", "https://cognitiveservices.azure.com/.default")
+CHAT_MODEL_BASE_URL = "/".join(
+    part for part in (CHAT_MODEL_ENDPOINT.rstrip("/"), CHAT_MODEL_API_PATH.strip("/")) if part
+)
 # OpenTelemetry configuration from Aspire
 OTLP_ENDPOINT = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "")
 SERVICE_NAME = os.environ.get("OTEL_SERVICE_NAME", "chatservice")
@@ -58,6 +69,13 @@ CAPTURE_MESSAGE_CONTENT = os.environ.get("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MES
 # CORS configuration - allow specific origins from environment, default to localhost dev servers
 CORS_ORIGINS = os.environ.get("CORS_ALLOWED_ORIGINS", "http://localhost:5173,http://localhost:5174").split(",")
 PROMPTS_DIR = Path(__file__).parent / "prompts"
+
+# Telemetry values derived from the resolved model endpoint.
+_CHAT_MODEL_URL = urlsplit(CHAT_MODEL_ENDPOINT)
+CHAT_MODEL_SERVER_ADDRESS = _CHAT_MODEL_URL.hostname or "localhost"
+CHAT_MODEL_SERVER_PORT = _CHAT_MODEL_URL.port or (443 if _CHAT_MODEL_URL.scheme == "https" else 80)
+# Foundry Local is a plain OpenAI-compatible server; Azure AI Foundry reports as azure.ai.openai.
+GENAI_PROVIDER_NAME = GENAI_PROVIDER_OPENAI if CHAT_MODEL_KEY else "azure.ai.openai"
 
 # Metrics - initialized after setup_telemetry
 chat_request_counter = None
@@ -274,10 +292,12 @@ app.add_middleware(
 # Instrument FastAPI with OpenTelemetry
 FastAPIInstrumentor.instrument_app(app)
 
-# Create OpenAI client for GitHub Models
+# Create the OpenAI-compatible client for the configured Microsoft Foundry endpoint.
+# Foundry Local injects a static API key; Azure AI Foundry authenticates with Microsoft Entra ID,
+# and the OpenAI SDK refreshes the bearer token on every request through the provider callable.
 openai_client = OpenAI(
-    base_url=GITHUB_MODELS_ENDPOINT,
-    api_key=GITHUB_TOKEN
+    base_url=CHAT_MODEL_BASE_URL,
+    api_key=CHAT_MODEL_KEY or get_bearer_token_provider(DefaultAzureCredential(), CHAT_MODEL_SCOPE)
 )
 
 
@@ -306,7 +326,7 @@ async def health_check():
 
 @app.post("/chat", response_model=ChatResponse)
 async def chat(request: ChatRequest):
-    """Chat endpoint that uses GitHub Models with dynamic prompt selection."""
+    """Chat endpoint that uses Microsoft Foundry with dynamic prompt selection."""
     start_time = time.time()
 
     tracer = trace.get_tracer(__name__)
@@ -359,19 +379,19 @@ async def chat(request: ChatRequest):
                 messages = render_messages(prompt, {"message": request.message})
                 model_params = get_model_parameters(prompt)
 
-            # Call GitHub Models
-            with tracer.start_as_current_span("github_models_call", kind=SpanKind.CLIENT) as model_span:
+            # Call the Microsoft Foundry chat model
+            with tracer.start_as_current_span("chat_model_call", kind=SpanKind.CLIENT) as model_span:
                 # Legacy attributes for backward compatibility
-                model_span.set_attribute("model", GITHUB_MODEL_NAME)
+                model_span.set_attribute("model", CHAT_MODEL_NAME)
                 model_span.set_attribute("temperature", model_params.get("temperature", 0.7))
 
                 # GenAI semantic conventions for Aspire dashboard visualization
                 model_span.set_attribute("gen_ai.operation.name", GENAI_OPERATION_CHAT)
-                model_span.set_attribute("gen_ai.provider.name", GENAI_PROVIDER_OPENAI)
-                model_span.set_attribute("gen_ai.request.model", GITHUB_MODEL_NAME)
+                model_span.set_attribute("gen_ai.provider.name", GENAI_PROVIDER_NAME)
+                model_span.set_attribute("gen_ai.request.model", CHAT_MODEL_NAME)
                 model_span.set_attribute("gen_ai.request.temperature", model_params.get("temperature", 0.7))
-                model_span.set_attribute("server.address", "models.github.ai")
-                model_span.set_attribute("server.port", 443)
+                model_span.set_attribute("server.address", CHAT_MODEL_SERVER_ADDRESS)
+                model_span.set_attribute("server.port", CHAT_MODEL_SERVER_PORT)
 
                 # Optional sensitive-content capture for GenAI visualizer.
                 if CAPTURE_MESSAGE_CONTENT:
@@ -382,7 +402,7 @@ async def chat(request: ChatRequest):
                         model_span.set_attribute("gen_ai.input.messages", json.dumps(input_messages))
 
                 response = openai_client.chat.completions.create(
-                    model=GITHUB_MODEL_NAME,
+                    model=CHAT_MODEL_NAME,
                     messages=messages,
                     temperature=model_params.get("temperature", 0.7)
                 )
@@ -445,7 +465,7 @@ async def chat(request: ChatRequest):
                 detail="Chat service is temporarily unavailable: prompt configuration is missing"
             )
         except Exception as e:
-            logger.error(f"Error calling GitHub Models: {e}")
+            logger.error(f"Error calling the chat model: {e}")
             if chat_request_counter:
                 chat_request_counter.add(1, {"status": "error", "prompt_style": prompt_file})
             raise HTTPException(

--- a/src/Garage.ChatService/prompts/brief.prompt.yml
+++ b/src/Garage.ChatService/prompts/brief.prompt.yml
@@ -1,6 +1,6 @@
 name: Le Mans Quick Facts
 description: Provides brief, factual Le Mans answers
-model: openai/gpt-4o
+model: microsoft/phi-4-mini
 modelParameters:
   temperature: 0.3
 messages:

--- a/src/Garage.ChatService/prompts/casual.prompt.yml
+++ b/src/Garage.ChatService/prompts/casual.prompt.yml
@@ -1,6 +1,6 @@
 name: Le Mans Buddy
 description: A friendly and casual Le Mans enthusiast
-model: openai/gpt-4o
+model: microsoft/phi-4-mini
 modelParameters:
   temperature: 0.9
 messages:

--- a/src/Garage.ChatService/prompts/expert.prompt.yml
+++ b/src/Garage.ChatService/prompts/expert.prompt.yml
@@ -1,6 +1,6 @@
 name: Le Mans Expert
 description: A knowledgeable Le Mans racing historian and expert
-model: openai/gpt-4o
+model: microsoft/phi-4-mini
 modelParameters:
   temperature: 0.7
 messages:

--- a/src/Garage.ChatService/prompts/unreliable.prompt.yml
+++ b/src/Garage.ChatService/prompts/unreliable.prompt.yml
@@ -1,6 +1,6 @@
 name: Unreliable Le Mans "Expert"
 description: A confidently incorrect Le Mans commentator who mixes up facts
-model: openai/gpt-4o
+model: microsoft/phi-4-mini
 modelParameters:
   temperature: 1.0
 messages:

--- a/src/Garage.ChatService/pyproject.toml
+++ b/src/Garage.ChatService/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Le Mans chatbot service"
 requires-python = ">=3.14"
 dependencies = [
+	"azure-identity==1.25.3",
 	"fastapi==0.141.1",
 	"grpcio==1.83.0",
 	"openai==2.53.0",

--- a/src/Garage.ChatService/test_prompt_loader.py
+++ b/src/Garage.ChatService/test_prompt_loader.py
@@ -154,7 +154,7 @@ class TestLoadPrompt:
         prompt_dir.mkdir()
         (prompt_dir / "full.prompt.yml").write_text(
             "name: Full Prompt\n"
-            "model: openai/gpt-4o\n"
+            "model: microsoft/phi-4-mini\n"
             "messages:\n"
             "  - role: system\n"
             "    content: You are helpful.\n"
@@ -163,7 +163,7 @@ class TestLoadPrompt:
             encoding="utf-8",
         )
         result = load_prompt("full", str(prompt_dir))
-        assert result["model"] == "openai/gpt-4o"
+        assert result["model"] == "microsoft/phi-4-mini"
         assert result["name"] == "Full Prompt"
         assert len(result["messages"]) == 1
         assert get_model_parameters(result) == {"temperature": 0.3}

--- a/src/Garage.ChatService/uv.lock
+++ b/src/Garage.ChatService/uv.lock
@@ -42,12 +42,100 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-core"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/f3/b416179e408990df5db0d516283022dde0f5d0111d98c1a848e41853e81c/azure_core-1.41.0.tar.gz", hash = "sha256:f46ff5dfcd230f25cf1c19e8a34b8dc08a337b2503e268bb600a16c00db8ad5a", size = 381042, upload-time = "2026-05-07T23:30:54.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/db/325c6d7312d2200251c52323878281045aaffcb5586612296484e4280eaa/azure_core-1.41.0-py3-none-any.whl", hash = "sha256:522b4011e8180b1a3dcd2024396a4e7fe9ac37fb8597db47163d230b5efe892d", size = 220920, upload-time = "2026-05-07T23:30:56.357Z" },
+]
+
+[[package]]
+name = "azure-identity"
+version = "1.25.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "msal" },
+    { name = "msal-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/0e/3a63efb48aa4a5ae2cfca61ee152fbcb668092134d3eb8bfda472dd5c617/azure_identity-1.25.3.tar.gz", hash = "sha256:ab23c0d63015f50b630ef6c6cf395e7262f439ce06e5d07a64e874c724f8d9e6", size = 286304, upload-time = "2026-03-13T01:12:20.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/9a/417b3a533e01953a7c618884df2cb05a71e7b68bdbce4fbdb62349d2a2e8/azure_identity-1.25.3-py3-none-any.whl", hash = "sha256:f4d0b956a8146f30333e071374171f3cfa7bdb8073adb8c3814b65567aa7447c", size = 192138, upload-time = "2026-03-13T01:12:22.951Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/f0/81478e482afa03f6d18dc8f2afb5edc45b3080853b634b5ed91961be0998/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a", size = 194142, upload-time = "2026-07-06T21:33:23.657Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/95/8de304305cd9204974b0ca051b86d307cafca13aa575a0ef1b44d92c0d8c/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3", size = 196819, upload-time = "2026-07-06T21:33:25.007Z" },
+    { url = "https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d", size = 184965, upload-time = "2026-07-06T21:33:26.605Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac", size = 184952, upload-time = "2026-07-06T21:33:27.823Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6", size = 222353, upload-time = "2026-07-06T21:33:29.178Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a5/e8bbb1ce5b3ac2f53ad6a10bde44318a5a8d99d4f4a000d44a6e39aeb3e4/cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913", size = 210051, upload-time = "2026-07-06T21:33:30.534Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ed/c127d3ac36e899c965e3361357c3befacd6578c03f40125183e41c3b219e/cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d", size = 208630, upload-time = "2026-07-06T21:33:31.753Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5", size = 221593, upload-time = "2026-07-06T21:33:33.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/27/93195977168ee63aed233a1a0993a2178798654d1f4bddcdd321d6fd3b21/cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce", size = 225146, upload-time = "2026-07-06T21:33:34.224Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c1/6dbd291ee2ae5a50a034aa057207081f545923bbf15dad4511e985aafff5/cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326", size = 223240, upload-time = "2026-07-06T21:33:35.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6f/ade5ce9863a57992a6ea3d0d10d7e29b8749fc127204b3d493d667b2815f/cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd", size = 177723, upload-time = "2026-07-06T21:33:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb", size = 187937, upload-time = "2026-07-06T21:33:53.403Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/cc6ae6c2913a03aab8898eee57963cf1035b8df5872ed8b9115fcc7e2be8/cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804", size = 183001, upload-time = "2026-07-06T21:33:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f0/134c00ce0779ec86dea2aa1aac69339c2741a8045072676763512363a2ea/cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714", size = 188538, upload-time = "2026-07-06T21:33:36.792Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d8/3b86aba791cb610d24e8a3e1b2cd529e71fa15096b04e4d4e360049d4a4c/cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376", size = 188230, upload-time = "2026-07-06T21:33:38.011Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d0/117dcd9209255ad8571fbc8c92ef32593a1d294dcec91ddc4e4db50606f2/cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98", size = 223899, upload-time = "2026-07-06T21:33:39.514Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3d/f20f8b886b254e3ad10e15cd4186d3aed49f3e6a35ab37aab9f8f25f7c03/cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13", size = 211652, upload-time = "2026-07-06T21:33:40.851Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3b/fad54de07260b93ddeef4b96d0131d57ea900675df1d410ae1deee52d7a6/cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d", size = 210755, upload-time = "2026-07-06T21:33:42.183Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/3d5c705acb7abbba9bbd7d79b8e62e0f25b6120eb7ae6ac49f1b721722fe/cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056", size = 223933, upload-time = "2026-07-06T21:33:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d0/47e338384ab6b1004241002fa616301020cea4fc95f283506565d252f276/cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4", size = 226749, upload-time = "2026-07-06T21:33:45.046Z" },
+    { url = "https://files.pythonhosted.org/packages/70/25/65bd5b58ea4bfdfc15cde02cb5365f89ef8ab8b2adfb8fe5c4bd4233382f/cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94", size = 225703, upload-time = "2026-07-06T21:33:46.374Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/78/aa01ac599a8a4322533d45a1f9bc93b338276d2d59dabbe7c6d92a775c81/cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76", size = 182857, upload-time = "2026-07-06T21:33:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/d00496b22de4d4228f32dde94ad996f350c8aad676d63bcca0743c8dea4d/cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5", size = 194065, upload-time = "2026-07-06T21:33:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dd/0c7dbf815a579ff005008a2d815a55d6bb047c349eef536d9dc53d3f0a8d/cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8", size = 186404, upload-time = "2026-07-06T21:33:50.309Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/8c8c50cb11c6750051daf12164098a9a6f027ac4356967fd4d800a07f242/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c", size = 194121, upload-time = "2026-07-06T21:33:56.109Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e2/67680bf19a6b60d2bb7ff83baefa2a4c3d2d7dc0f3277034b802e1fc504c/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001", size = 196820, upload-time = "2026-07-06T21:33:57.288Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/da/4bbe583a3b3a5c8c60892124fe17f3fa3656523faf0d3484eae90f091853/cffi-2.1.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:95f2954c2c9473d892eca6e0409f3568b37ab62a8eedb122461f73cc273476e3", size = 184936, upload-time = "2026-07-06T21:33:58.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4b/1f4c36ab273980d7aa75bb126ea4f8971f24a96108acad3a0a084028c57b/cffi-2.1.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:cdf2448aab5f661c9315308ec8b93f4e8a1a67a3c733f8631067a2b67d5913dc", size = 185045, upload-time = "2026-07-06T21:34:00.085Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c3/ad299dc38f3583f8d916b299f028af418a9ec98bc695fcbebeae7420691c/cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699", size = 222342, upload-time = "2026-07-06T21:34:01.814Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d8/df4543cc087245044ed02ef3ad8e0a26619d0075ac7a77a12dc81177851b/cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022", size = 210073, upload-time = "2026-07-06T21:34:03.255Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/fac738d73728c6cea2a88a2883dca54892496cbba88a1dc1f2909cb8a6f5/cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0", size = 208551, upload-time = "2026-07-06T21:34:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3f/0b04a700dd64f465c93020253a793a82c9b4dff9961f48facd0df945d9b8/cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1", size = 221649, upload-time = "2026-07-06T21:34:06.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/b7379a5704c79eda57ce075869ba70a0368d1c850f803b3c0d078d39dcaf/cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28", size = 225203, upload-time = "2026-07-06T21:34:07.489Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/02/d5e6c43ea85c41bda2a184a3418f195fe7cf602967a8d2b94e085b83deef/cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629", size = 223263, upload-time = "2026-07-06T21:34:08.712Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d8/772b8259bf75749adffb1c546828978381fb516f60cf701f6c83daf60c85/cffi-2.1.0-cp315-cp315-win32.whl", hash = "sha256:0a42c688d19fca6e095a53c6a6e2295a5b050a8b289f109adab02a9e61a25de6", size = 177696, upload-time = "2026-07-06T21:34:26.355Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/dd/afa2191fc6d57fedd26e5844a2fe2fcc0bbfa00961bbaa5a41e4921e7cca/cffi-2.1.0-cp315-cp315-win_amd64.whl", hash = "sha256:bccbbb5ee76a61f9d99b5bf3846a51d7fca4b6a732fe46f89295610edaf41853", size = 187914, upload-time = "2026-07-06T21:34:27.58Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ef/6cd4f8c671517162379dc79cfae5aea9106bc38abb89628d5c16adf6a838/cffi-2.1.0-cp315-cp315-win_arm64.whl", hash = "sha256:8d35c139744adb3e727cd51b1a18324bbe44b8bd41bf8322bca4d41289f48eda", size = 183004, upload-time = "2026-07-06T21:34:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b6/12fc55092817a5faa26fb8c40c7f9d662e11a46ee248c137aafc42517d92/cffi-2.1.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:f9912624a0c0b834b7520d7769b3644453aabc0a7e1c839da7359f050750e9bc", size = 188378, upload-time = "2026-07-06T21:34:09.926Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2e/cdac88979f295fde5daa69622c7d2111e56e7ceb94f211357fbe452339e4/cffi-2.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:df92f2aba50eb4d96718b68ef76f2e57a57b54f2fa62333496d16c6d585a85ca", size = 188319, upload-time = "2026-07-06T21:34:11.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/27/1d0b408497e41a74795af122d7b603c418c5fed0171450f899afd04e594f/cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d", size = 223904, upload-time = "2026-07-06T21:34:12.606Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/31/e115c985105dd7ffb32444505f18ceb874bb42d992af05d5dced7ecf1980/cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8", size = 211554, upload-time = "2026-07-06T21:34:13.987Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/67/9e6e09409336d9e515c58367e7cfcf4f89df06ad25252675595a58eb59d5/cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd", size = 210795, upload-time = "2026-07-06T21:34:15.972Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e5/d3cc82a4a0be7902af279c04181ad038449c096734464a5ae1de3e1401bd/cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f", size = 223843, upload-time = "2026-07-06T21:34:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/65/b434abc97ce7cecc2c640fde160507c0ecc7e21544b483ba3325d2e2ea17/cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc", size = 226773, upload-time = "2026-07-06T21:34:19.05Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9f/d4dc66ca651eb1145a133314cda721abf13cfac3d28c4a0402263ae6ad75/cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9", size = 225719, upload-time = "2026-07-06T21:34:20.576Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5a/e536c528bc8057496c360c0978559a2dc45653f89dd6151078aa7d8fca1a/cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b", size = 182760, upload-time = "2026-07-06T21:34:22.059Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/0ffe8b82d3875bced5fa1e7986a7a46b748262a40ab7f60b475eb9fb1bb3/cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5", size = 193769, upload-time = "2026-07-06T21:34:23.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/17/1073b53b68c9b5ca6914adf5f8bf55aacc2d3be102418c90700160ea8605/cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210", size = 186405, upload-time = "2026-07-06T21:34:24.857Z" },
 ]
 
 [[package]]
@@ -107,6 +195,56 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -136,6 +274,7 @@ name = "garage-chatservice"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "azure-identity" },
     { name = "fastapi" },
     { name = "grpcio" },
     { name = "openai" },
@@ -158,6 +297,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "azure-identity", specifier = "==1.25.3" },
     { name = "fastapi", specifier = "==0.141.1" },
     { name = "grpcio", specifier = "==1.83.0" },
     { name = "openai", specifier = "==2.53.0" },
@@ -298,6 +438,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
     { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
     { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+]
+
+[[package]]
+name = "msal"
+version = "1.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/99/d840198ecf6e8057bbc937f129ae940404485d736cda73253bbff9537f01/msal-1.37.0.tar.gz", hash = "sha256:1b1672a33ee467c1d70b341bb16cafd51bb3c817147a95b93263794b03971bec", size = 182444, upload-time = "2026-05-29T19:49:05.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/b0/d807279f4b55d16d1f120d5ac4344c6e39b56732e2a224d40bded7fd67ad/msal-1.37.0-py3-none-any.whl", hash = "sha256:dd17e95a7c71bce75e8108113438ba7c4a086b3bcad4f57a8c09b7af3d753c2d", size = 123725, upload-time = "2026-05-29T19:49:04.335Z" },
+]
+
+[[package]]
+name = "msal-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/99/5d239b6156eddf761a636bded1118414d161bd6b7b37a9335549ed159396/msal_extensions-1.3.1.tar.gz", hash = "sha256:c5b0fd10f65ef62b5f1d62f4251d51cbcaf003fcedae8c91b040a488614be1a4", size = 23315, upload-time = "2025-03-14T23:51:03.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/75/bd9b7bb966668920f06b200e84454c8f3566b102183bc55c5473d96cb2b9/msal_extensions-1.3.1-py3-none-any.whl", hash = "sha256:96d3de4d034504e969ac5e85bae8106c8373b5c6568e4c8fa7af2eca9dbe6bca", size = 20583, upload-time = "2025-03-14T23:51:03.016Z" },
 ]
 
 [[package]]
@@ -526,6 +692,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -588,6 +763,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]


### PR DESCRIPTION
GitHub Models was retired on 2026-07-30, so the chat service can no longer reach `models.github.ai` and the chatbot demo is dead in the water. This migrates it to Microsoft Foundry.

## Approach

Swaps `Aspire.Hosting.GitHub.Models` for `Aspire.Hosting.Foundry`. The AppHost declares a single Foundry resource that runs as Foundry Local during `aspire run` and provisions an Azure AI Foundry account when published:

```csharp
var foundry = builder.AddFoundry("foundry").RunAsFoundryLocal();
var chatModel = foundry.AddDeployment("chat-model",
    builder.ExecutionContext.IsPublishMode
        ? FoundryModel.Microsoft.Phi4MiniInstruct
        : FoundryModel.Local.Phi4Mini);
```

Keeping the deployment named `chat-model` means Aspire still injects `CHAT_MODEL_URI`, `CHAT_MODEL_KEY`, and `CHAT_MODEL_MODELNAME`, so the Python service keeps reading the same variables and the diff there stays small. The `openai` SDK is unchanged since both endpoints are OpenAI-compatible. The `github-token` secret parameter is gone, and `chatservice` now waits for the model to finish loading.

## Two things worth a careful look

**The endpoint shape differs between modes.** Foundry Local hands out a complete OpenAI base URL with `/v1` already appended, while Azure exposes only the account root. My first attempt appended `/v1` unconditionally, which produced a doubled path and a bare `Error code: 404`. The AppHost now injects `CHAT_MODEL_API_PATH=openai/v1` in publish mode only, and the service joins non-empty segments, so there is no URL sniffing anywhere.

**Azure has no API key.** The generated Bicep sets `disableLocalAuth: true`, so auth has to be Entra ID. This adds `azure-identity` plus a `CognitiveServicesUser` role assignment, which also makes Aspire inject `AZURE_CLIENT_ID`. The service picks a static key vs `get_bearer_token_provider` based on whether `CHAT_MODEL_KEY` is present.

Telemetry was updated to match: the `github_models_call` span is now `chat_model_call`, and `server.address`, `server.port`, and `gen_ai.provider.name` are derived from the resolved endpoint instead of hard-coded to `models.github.ai`.

## Model choice

Phi-4-mini rather than full Phi-4. Full Phi-4 downloads about 9 GB and took over 100 seconds per reply on an Apple Silicon laptop, since Foundry Local picks the generic-gpu ONNX build. Mini answers in roughly 2 seconds warm. Same family, and it keeps the demo usable on a dev machine.

## Verification

- `dotnet build`, `dotnet format --verify-no-changes`, and 41/41 pytest all pass.
- `aspire run` brings up `foundry`, `chat-model`, and `chatservice` healthy, and the chatbot answers correctly through the React UI with the `expert` prompt style badge, so the OpenFeature `enable-chatbot` and `prompt-file` flags still drive everything.
- Traces confirm the renamed `chat_model_call` span pointing at `chat-model` with GenAI input/output capture intact.
- `aspire publish` renders valid Bicep with the correct role assignment, `AZURE_CLIENT_ID`, `CHAT_MODEL_API_PATH=openai/v1`, and a `Phi-4-mini-instruct` deployment.

**One caveat:** publish mode was validated only through generated Bicep, not an actual deployment. If Azure-hosted Phi-4-mini turns out not to serve over `/openai/v1/`, `CHAT_MODEL_AIINFERENCEURI` (the `/models` AI Inference route) is the fallback. Since the path is an env var, that would be a config change rather than a code change.

## Follow-up

The stale `Parameters:github-token` user secret is left alone since it lives outside the repo. It is inert now and can be removed with `dotnet user-secrets remove "Parameters:github-token"`.