### PR TITLE
ci: gate all checks behind a single required job

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -246,16 +246,24 @@ Currently, there are no test projects in the solution. When adding tests:
    - Jobs: `changes` → `build-dotnet` (restore, `dotnet format --verify-no-changes`, Release
      build), `build-go` (`gofmt` check, `go test ./...`), `build-python` (`uv sync`, `pytest`),
      `build-web` (`npm ci`, lint, build) → `ci-gate`.
-   - `ci-gate` (`CI Gate`) is the **single required status check** on `main`. It runs on
-     `ubuntu-slim` with `if: always()`, and fails if any job it needs did not succeed. The four
+   - `ci-gate` (`CI Gate`) is the **gating job**. It runs on `ubuntu-slim` with
+     `if: always()`, and fails if any job it needs did not succeed. The four
      language builds are listed in its `ALLOWED_SKIPS`, so a skip-by-design passes; `changes`
      is not, and `cancelled` is never tolerated.
+   - By design `CI Gate` is meant to be the **only** status check the `main` ruleset requires,
+     so the ruleset does not have to change when CI jobs do. Check what is actually required
+     with:
+
+     ```bash
+     gh api repos/askpt/openfeature-aspire-sample/rulesets/5427048 \
+       --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks'
+     ```
 
 > [!IMPORTANT]
 > When adding a new CI job, add it to the `ci-gate` job's `needs:` list, otherwise it is
 > advisory and a pull request can merge while it is failing. Only add it to `ALLOWED_SKIPS` if
-> it is genuinely skipped by design. The repository ruleset requires `CI Gate` only, so it
-> never needs editing when jobs are added or removed.
+> it is genuinely skipped by design. As long as the ruleset requires `CI Gate` and nothing
+> else, it never needs editing when jobs are added or removed.
 
 2. **Copilot Setup Steps** (`.github/workflows/copilot-setup-steps.yml`)
    - Provisions the .NET, Go, Node.js and Python toolchains for the Copilot coding agent.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -237,13 +237,29 @@ Currently, there are no test projects in the solution. When adding tests:
 ### GitHub Actions Workflows
 
 1. **CI Build** (`.github/workflows/ci.yml`)
-   - Runs on push to main and all PRs
-   - Builds with `dotnet build --configuration Release`
-   - Tests are commented out (add when test projects exist)
+   - Runs on every pull request and on every push to `main`. Deliberately has **no
+     workflow-level `paths:` filter** — a workflow skipped by a path filter never creates its
+     check runs, which leaves a required status check pending forever.
+   - `changes` uses `dorny/paths-filter` to decide which language builds are needed. Each
+     build job is skipped via `if:` when its paths are untouched, and a skipped job still
+     reports a conclusion, so nothing hangs.
+   - Jobs: `changes` → `build-dotnet` (restore, `dotnet format --verify-no-changes`, Release
+     build), `build-go` (`gofmt` check, `go test ./...`), `build-python` (`uv sync`, `pytest`),
+     `build-web` (`npm ci`, lint, build) → `ci-gate`.
+   - `ci-gate` (`CI Gate`) is the **single required status check** on `main`. It runs on
+     `ubuntu-slim` with `if: always()`, and fails if any job it needs did not succeed. The four
+     language builds are listed in its `ALLOWED_SKIPS`, so a skip-by-design passes; `changes`
+     is not, and `cancelled` is never tolerated.
 
-2. **Format Check** (`.github/workflows/format.yml`)
-   - Runs on push to main and PRs to main
-   - Verifies code formatting with `dotnet format --verify-no-changes`
+> [!IMPORTANT]
+> When adding a new CI job, add it to the `ci-gate` job's `needs:` list, otherwise it is
+> advisory and a pull request can merge while it is failing. Only add it to `ALLOWED_SKIPS` if
+> it is genuinely skipped by design. The repository ruleset requires `CI Gate` only, so it
+> never needs editing when jobs are added or removed.
+
+2. **Copilot Setup Steps** (`.github/workflows/copilot-setup-steps.yml`)
+   - Provisions the .NET, Go, Node.js and Python toolchains for the Copilot coding agent.
+   - Environment setup rather than a CI check, so it is intentionally outside the gate.
 
 ## Dependencies and Security
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 name: CI Build
 
-# Deliberately unfiltered by path. `ci-gate` is the single required status check, and a
-# workflow skipped by a `paths:` filter never creates its check runs - a required context
-# that never reports stays pending forever, which is why docs-only changes used to need a
-# ruleset bypass. Per-language filtering happens in the `changes` job instead, where a
-# skipped job still reports a conclusion.
+# Deliberately unfiltered by path. `ci-gate` is the job that gates merges, and a workflow
+# skipped by a `paths:` filter never creates its check runs - a required context that never
+# reports stays pending forever, which is why docs-only changes used to need a ruleset
+# bypass. Per-language filtering happens in the `changes` job instead, where a skipped job
+# still reports a conclusion.
 on:
   push:
     branches:
@@ -186,8 +186,9 @@ jobs:
       - name: Build
         run: npm run build
 
-  # The single required status check. Every other job hangs off this one, so gating a new
-  # job means adding it to `needs:` here - the ruleset never has to be edited again.
+  # The gating job. Every other job hangs off this one, so gating a new job means adding it
+  # to `needs:` here. It is intended to be the only status check the `main` ruleset
+  # requires, so the ruleset does not have to change when CI jobs do.
   ci-gate:
     name: CI Gate
     # `always()` is load-bearing. Without it the job inherits the implicit `success()`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,11 @@ jobs:
       contents: read
     steps:
       - name: Check that every gated job succeeded
+        # GitHub's default shell is `bash -e {0}` - `set -e` but *no* `pipefail`. Naming
+        # the shell explicitly upgrades it to `bash --noprofile --norc -eo pipefail {0}`,
+        # so a failure anywhere in `echo ... | jq ...` is observed rather than masked by
+        # jq's own exit status. A gate that fails open is worse than no gate at all.
+        shell: bash
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
           # Comma-separated jobs allowed to report `skipped`. The four language builds are
@@ -209,21 +214,36 @@ jobs:
           # its own result is left to fail the gate.
           ALLOWED_SKIPS: "build-dotnet,build-go,build-python,build-web"
         run: |
+          # Restated rather than relying on the shell keyword alone, so the script behaves
+          # the same when extracted and run outside Actions.
+          set -euo pipefail
+
+          # An empty `needs` would sail through every check below and report success
+          # without gating anything - e.g. if a future edit drops the `needs:` key.
+          # Assigned rather than inlined into the `if`, because `set -e` is suspended
+          # inside a condition: a jq parse failure there would fall through to the
+          # comparison instead of aborting.
+          job_count=$(jq -r 'length' <<<"$NEEDS_JSON")
+          if [ "$job_count" -eq 0 ]; then
+            echo "::error::CI Gate has no upstream jobs to check; its needs list is empty."
+            exit 1
+          fi
+
           {
             echo "### CI Gate"
             echo ""
             echo "| Job | Result |"
             echo "| --- | --- |"
-            echo "$NEEDS_JSON" | jq -r 'to_entries[] | "| \(.key) | \(.value.result) |"'
+            jq -r 'to_entries[] | "| \(.key) | \(.value.result) |"' <<<"$NEEDS_JSON"
           } >> "$GITHUB_STEP_SUMMARY"
 
-          failing=$(echo "$NEEDS_JSON" | jq -r --arg allowed "$ALLOWED_SKIPS" '
+          failing=$(jq -r --arg allowed "$ALLOWED_SKIPS" '
             ($allowed | split(",") | map(select(length > 0))) as $ok
             | to_entries[]
             | select(.value.result != "success")
             | select(.value.result != "skipped" or ([.key] - $ok | length) > 0)
             | "\(.key): \(.value.result)"
-          ')
+          ' <<<"$NEEDS_JSON")
 
           if [ -n "$failing" ]; then
             echo "::error::One or more gated jobs did not succeed:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,26 +1,28 @@
 name: CI Build
 
+# Deliberately unfiltered by path. `ci-gate` is the single required status check, and a
+# workflow skipped by a `paths:` filter never creates its check runs - a required context
+# that never reports stays pending forever, which is why docs-only changes used to need a
+# ruleset bypass. Per-language filtering happens in the `changes` job instead, where a
+# skipped job still reports a conclusion.
 on:
   push:
     branches:
       - "main"
-    paths:
-      - "src/**"
-      - "**/*.props"
-      - "*.slnx"
-      - "global.json"
-      - ".github/workflows/ci.yml"
   pull_request:
-    paths:
-      - "src/**"
-      - "**/*.props"
-      - "*.slnx"
-      - "global.json"
-      - ".github/workflows/ci.yml"
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  # Supersede in-flight runs for the same pull request only. Runs on `main` are never
+  # cancelled, so the commit that lands always keeps a complete set of results.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
 
 jobs:
   changes:
@@ -36,6 +38,8 @@ jobs:
       web: ${{ steps.filter.outputs.web }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
@@ -70,6 +74,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - name: Cache NuGet packages
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -102,6 +108,8 @@ jobs:
         working-directory: src/Garage.FeatureFlags
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -132,6 +140,8 @@ jobs:
         working-directory: src/Garage.ChatService
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -161,6 +171,8 @@ jobs:
         working-directory: src/Garage.Web
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -173,3 +185,50 @@ jobs:
         run: npm run lint
       - name: Build
         run: npm run build
+
+  # The single required status check. Every other job hangs off this one, so gating a new
+  # job means adding it to `needs:` here - the ruleset never has to be edited again.
+  ci-gate:
+    name: CI Gate
+    # `always()` is load-bearing. Without it the job inherits the implicit `success()`
+    # condition and reports as *skipped* when a dependency fails - and a skipped check
+    # satisfies a ruleset, letting through exactly the pull requests this is meant to stop.
+    if: always()
+    needs: [changes, build-dotnet, build-go, build-python, build-web]
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Check that every gated job succeeded
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+          # Comma-separated jobs allowed to report `skipped`. The four language builds are
+          # skipped by design when `changes` reports their paths were untouched. `changes`
+          # is deliberately absent: if it fails, the builds cascade to `skipped` and only
+          # its own result is left to fail the gate.
+          ALLOWED_SKIPS: "build-dotnet,build-go,build-python,build-web"
+        run: |
+          {
+            echo "### CI Gate"
+            echo ""
+            echo "| Job | Result |"
+            echo "| --- | --- |"
+            echo "$NEEDS_JSON" | jq -r 'to_entries[] | "| \(.key) | \(.value.result) |"'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          failing=$(echo "$NEEDS_JSON" | jq -r --arg allowed "$ALLOWED_SKIPS" '
+            ($allowed | split(",") | map(select(length > 0))) as $ok
+            | to_entries[]
+            | select(.value.result != "success")
+            | select(.value.result != "skipped" or ([.key] - $ok | length) > 0)
+            | "\(.key): \(.value.result)"
+          ')
+
+          if [ -n "$failing" ]; then
+            echo "::error::One or more gated jobs did not succeed:"
+            echo "$failing"
+            exit 1
+          fi
+
+          echo "All gated jobs succeeded or were intentionally skipped."


### PR DESCRIPTION
## Why

Branch protection on `main` requires four status checks directly: `build-dotnet`, `build-go`, `build-web` and `build-python`. `ci.yml` also filters on `paths:` at the **workflow** level.

Those two things do not compose. A pull request that touches none of the filtered paths never triggers the workflow, so those four check runs are never created, and a required context that is never created does not fail — it sits *"Expected — waiting for status to be reported"* indefinitely. That is why a change to `README.md`, `.gitignore`, `.github/dependabot.yml`, `nuget.config`, `aspire.config.json`, `.devcontainer/**` or `.vscode/**` currently needs a ruleset bypass to merge.

It is worth being precise about which layer is at fault, because the repo has two:

| Layer | Mechanism | Behaviour when it filters |
| --- | --- | --- |
| Workflow trigger | `on.push.paths` / `on.pull_request.paths` | Workflow never runs → check runs never created → **required context pending forever** |
| Job condition | `changes` job + `dorny/paths-filter` + per-job `if:` | Job reports a check run with conclusion `skipped`, which rulesets treat as satisfied → fine |

Only the first one is broken. The per-language filtering is doing exactly what it should.

## Approach

Drop the workflow-level `paths:` filters so `ci.yml` always runs, keep the `changes` job so per-language work is still skipped, and add a `CI Gate` job downstream of everything else that turns "skipped by design" into a green required check.

```
ci.yml  (always triggers)
  changes                                    dorny/paths-filter
    build-dotnet   if: dotnet == 'true'
    build-go       if: go     == 'true'
    build-python   if: python == 'true'
    build-web      if: web    == 'true'
  ci-gate  needs: [changes, build-*]         <- the only required check
           if: always()   runs-on: ubuntu-slim
```

Cost is essentially flat. A docs-only pull request now runs `changes` plus `ci-gate` — two short jobs — instead of nothing, and merges without a bypass. Everything else behaves as it did.

Once the ruleset requires `CI Gate` instead of the four builds, jobs can be added and removed without anyone having to remember to edit branch protection.

## Differences from open-feature/dotnet-sdk-contrib#726

- **No merge queue.** No `merge_group` trigger and none of the queue-specific handling from that change.
- **`CI Gate` runs on `ubuntu-slim`.** The job does nothing but run `jq`, and [that image ships `jq` 1.7](https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md), so the script is unchanged. Other jobs stay on `ubuntu-latest`.
- **`pull_request` is left unfiltered by branch.** #726 adds `branches: [main]`; here that would mean a stacked pull request targeting a feature branch gets no `CI Gate` at all. Leaving it off guarantees every pull request produces the required check.
- **No reusable-workflow refactor.** #726 needed one because its checks spanned `ci.yml` and `dotnet-format.yml`, and `needs:` cannot reference a job in another workflow file. Everything here already lives in `ci.yml`, so the gate is just one more job.

`copilot-setup-steps.yml` is agent environment setup rather than a CI check, so it is deliberately outside the gate.

## Design notes

- **`if: always()` is load-bearing.** Without it the gate inherits the implicit `success()` condition and is reported as *skipped* when a dependency fails — and a skipped check satisfies a ruleset. That would let through exactly the pull requests it is meant to stop.
- **`ALLOWED_SKIPS` contains only the four language builds.** `changes` is deliberately absent: if it fails, all four builds cascade to `skipped` and its own `failure` result is the only thing left to fail the gate. Verified below.
- **`cancelled` is never tolerated**, including for allow-listed jobs — the second `select` forgives only the literal result `skipped`.
- **Adding a future job to `needs:` is all that is required to gate it.** A new job that is *not* added stays advisory, which is the one footgun worth knowing about; it is called out in the contributor instructions.

## Fixed along the way

- `cancel-in-progress` was `${{ github.ref != 'refs/heads/main' }}`, now `${{ github.event_name == 'pull_request' }}`. Behaviourally equivalent — `push` only fires on `main`, where the old expression was already false — but it states the intent rather than inferring it from the ref.
- Added a workflow-level `permissions: contents: read` so any job added later starts locked down. Existing job-level blocks are unchanged and continue to override it; `changes` keeps its `pull-requests: read`.
- All five checkouts now set `persist-credentials: false`. Nothing runs git after checkout and `nuget.config` points only at nuget.org, so there is no reason to leave the job token in `.git/config`. This clears all five `artipacked` findings.
- The CI section of `.github/copilot-instructions.md` described a `.github/workflows/format.yml` that does not exist and a CI workflow that only builds .NET. Rewritten to match the real job graph.

## Required after merging this

Unlike #726, nothing is renamed here — the four `build-*` jobs still exist and still report — so no context goes permanently pending and the ruleset edit can safely happen **after** the merge:

```bash
# Swap the four build-* contexts for the single CI Gate context.
# Reads the live ruleset, rewrites only the required_status_checks rule, writes it back.
gh api repos/askpt/openfeature-aspire-sample/rulesets/5427048 \
  | jq '{rules: (.rules | map(
      if .type == "required_status_checks"
      then .parameters.required_status_checks = [{context: "CI Gate", integration_id: 15368}]
      else . end))}' \
  | gh api -X PUT repos/askpt/openfeature-aspire-sample/rulesets/5427048 --input -

# Verify
gh api repos/askpt/openfeature-aspire-sample/rulesets/5427048 \
  --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks'
```

`integration_id: 15368` is GitHub Actions, matching the existing entries. The `jq` rewrite touches only that one rule, so `strict_required_status_checks_policy`, `code_scanning`, `code_quality`, `copilot_code_review`, `required_signatures`, `required_linear_history`, squash-only merges and thread resolution are all preserved.

## Validation

- `actionlint` 1.7.12 — clean.
- `zizmor` 1.29.0 — 5 `artipacked` findings before, 0 after.
- The gate's `run:` script was extracted verbatim and exercised offline against synthetic `needs` payloads. All 11 assertions pass:

| Scenario | Expected | Result |
| --- | --- | --- |
| All five `success` | exit 0 | ✅ |
| Docs-only: `changes` success, four builds `skipped` | exit 0 | ✅ |
| Web-only: three builds `skipped` | exit 0 | ✅ |
| `build-go` `failure` | exit 1, names `build-go` | ✅ |
| `changes` `failure`, builds cascade to `skipped` | exit 1, names `changes` only | ✅ |
| `build-web` `cancelled` | exit 1 despite allow-list | ✅ |
| `changes` `skipped` | exit 1 | ✅ |
| Unknown job `skipped` | exit 1 | ✅ |
| Unknown job `success` | exit 0 | ✅ |
| Cascaded skips excluded from the failure list | not named | ✅ |
| Step summary renders one row per job | 5 rows | ✅ |

This pull request's own run is the end-to-end evidence for the all-green path: it edits `.github/workflows/ci.yml`, which appears in all four `paths-filter` globs, so every build runs and `CI Gate` has to aggregate five real results rather than skips. The skip path is covered by the offline cases above, and will be exercised for real by the first pull request that touches only documentation.
