### PR TITLE
Align devcontainer with the recommended Aspire configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,0 @@
-FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
-
-# Remove Yarn apt repository with expired GPG key
-RUN rm -f /etc/apt/sources.list.d/yarn.list || true

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,29 @@
 {
   "name": "OpenFeature Aspire Sample",
-  "build": {
-    "dockerfile": "Dockerfile"
-  },
+  "image": "mcr.microsoft.com/devcontainers/dotnet:dev-10.0-noble",
   "features": {
-    "ghcr.io/devcontainers/features/github-cli:latest": {},
-    "ghcr.io/devcontainers/features/dotnet:2": {
-      "version": "10.0"
-    },
-    "ghcr.io/devcontainers/features/node": {
+    "ghcr.io/microsoft/aspire-devcontainer-feature/aspire:2": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/powershell:1": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22",
       "installYarnUsingApt": false
     },
-    "ghcr.io/devcontainers/features/python": {
-      "version": "3.12"
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.14"
     },
-    "ghcr.io/devcontainers/features/go": {},
-    "ghcr.io/dotnet/aspire-devcontainer-feature/dotnetaspire:latest": {},
-    "ghcr.io/devcontainers/features/docker-in-docker": {}
+    "ghcr.io/devcontainers-extra/features/uv:1": {},
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "1.26.3"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {}
   },
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "16gb",
+    "storage": "32gb"
+  },
+  "postStartCommand": "dotnet dev-certs https --trust",
   "customizations": {
     "vscode": {
       "extensions": [
@@ -40,9 +46,5 @@
       ]
     }
   },
-  "remoteUser": "vscode",
-  "hostRequirements": {
-    "memory": "8gb"
-  },
-  "postStartCommand": "dotnet dev-certs https --trust"
+  "remoteUser": "vscode"
 }

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@ This repository is set up to use Aspire. Aspire is an orchestrator for the entir
 
 - **.NET**: 10.0 (latest version)
 - **Python**: 3.14+ (for Chat Service with Microsoft Foundry)
-- **Go**: 1.25 (for Feature Flags API)
+- **Go**: 1.26 (for Feature Flags API)
 - **Frontend**: React 19.2 with TypeScript, Vite 7.2
 - **Backend**: ASP.NET Core 10.0 with Entity Framework Core
 - **Orchestration**: .NET Aspire 13.0
@@ -147,7 +147,7 @@ uvx mypy .
 
 ### Go Code
 
-- **Go Version**: 1.25 or later
+- **Go Version**: 1.26 or later
 - **Formatting**: Use `go fmt` for code formatting
 - **Error Handling**: Follow Go idioms for error handling
 - **Telemetry**: OpenTelemetry integration for tracing, metrics, and logging

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -139,12 +139,12 @@ updates:
           - "golang"
           - "alpine"
 
-  - package-ecosystem: "docker"
-    directory: ".devcontainer/"
+  - package-ecosystem: "devcontainers"
+    directory: "/"
     schedule:
       interval: daily
     open-pull-requests-limit: 5
     groups:
-      devcontainer-base:
+      devcontainer:
         patterns:
-          - "mcr.microsoft.com/devcontainers/*"
+          - "*"

--- a/.github/github-app.yml
+++ b/.github/github-app.yml
@@ -1,0 +1,10 @@
+scripts:
+  - name: Dev server
+    command: aspire run
+  - name: Restore
+    command: dotnet restore
+    triggers:
+      - session.create
+automation:
+  auto_issue_session: true
+  remote_control: false

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
       with:
         cache-dependency-path: src/Garage.FeatureFlags/go.sum
-        go-version: "1.25"
+        go-version-file: src/Garage.FeatureFlags/go.mod
     - name: Set up Node.js
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
       with:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![.NET 10.0](https://img.shields.io/badge/.NET-10.0-512BD4?logo=dotnet)](https://dotnet.microsoft.com/)
 [![Python 3.14](https://img.shields.io/badge/Python-3.14-3776AB?logo=python)](https://python.org/)
-[![Go 1.25](https://img.shields.io/badge/Go-1.25-00ADD8?logo=go)](https://go.dev/)
+[![Go 1.26](https://img.shields.io/badge/Go-1.26-00ADD8?logo=go)](https://go.dev/)
 [![Aspire 13.2](https://img.shields.io/badge/Aspire-13.2-purple)](https://learn.microsoft.com/en-us/dotnet/aspire/)
 [![OpenFeature](https://img.shields.io/badge/OpenFeature-Ready-green)](https://openfeature.dev/)
 [![OFREP](https://img.shields.io/badge/OFREP-Enabled-blue)](https://openfeature.dev/specification/ofrep)
@@ -84,13 +84,24 @@ The chatbot supports multiple prompt styles via GitHub Repository Prompts (`.pro
 
 - .NET 10.0 SDK or later
 - Python 3.14 or later
-- Go 1.25 or later (for Feature Flags API)
+- Go 1.26 or later (for Feature Flags API)
 - Node.js 22 or later (for React frontend)
 - Visual Studio, Visual Studio Code with C# extension or JetBrains Rider
 - Git for version control
 - Docker Desktop (for containerized dependencies)
 - Azure account (for Dev Tunnels authentication during development)
 - [Foundry Local](https://learn.microsoft.com/azure/ai-foundry/foundry-local/get-started) (for chatbot functionality)
+
+### Develop in a Dev Container or GitHub Codespaces
+
+Instead of installing the prerequisites yourself, you can open the repository in a container. The `.devcontainer/devcontainer.json` follows the [recommended Aspire dev container configuration](https://aspire.dev/get-started/github-codespaces/#manually-configuring-devcontainerjson) and preinstalls the whole toolchain — the .NET 10 SDK, the Aspire CLI, Node.js 22, Python 3.14 with `uv`, Go 1.26, PowerShell, the GitHub CLI and Docker-in-Docker — plus a trusted local HTTPS development certificate.
+
+- **GitHub Codespaces**: select **Code** → **Codespaces** → **Create codespace on main**. The container requests a 4-core / 16 GB machine.
+- **VS Code locally**: install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) and run **Dev Containers: Reopen in Container**.
+
+Once the container is ready, skip ahead to [Restore Dependencies](#3-restore-dependencies) — `aspire run` is available immediately.
+
+> **Note:** The container does not ship Foundry Local, so the chatbot resource only works when you run the app on your host machine.
 
 ## Quick Start
 


### PR DESCRIPTION
## Why

The dev container had drifted from both the [recommended Aspire configuration](https://aspire.dev/get-started/github-codespaces/#manually-configuring-devcontainerjson) and from this repo's own toolchain requirements. Most notably it pinned Python 3.12 while `Garage.ChatService` declares `requires-python = ">=3.14"`, and it never installed `uv` at all even though that service is uv-managed. It also still used the superseded v1 Aspire feature.

## What changed

`.devcontainer/devcontainer.json` is rebuilt on the [microsoft/aspire-devcontainer](https://github.com/microsoft/aspire-devcontainer) template, then layered with the extras this polyglot sample needs (Go, GitHub CLI, the existing VS Code extension list):

- Base is now the `mcr.microsoft.com/devcontainers/dotnet:dev-10.0-noble` image, so the separate `dotnet:2` feature is dropped. The image already ships an SDK that satisfies `global.json`.
- Aspire feature moved off v1 `ghcr.io/dotnet/.../dotnetaspire` to `ghcr.io/microsoft/aspire-devcontainer-feature/aspire:2`.
- Python 3.12 -> 3.14, and the `uv` feature added.
- PowerShell added (from the template). Node pinned to 22, Go to 1.26.3, and every feature pinned to a major version instead of floating on `:latest`.
- `.devcontainer/Dockerfile` deleted. It only existed to remove an expired Yarn apt repo from the old base image, which `installYarnUsingApt: false` on the node feature already handles.

## Things worth a look

**`hostRequirements` is deliberately not the template's values.** The template asks for 8 cpus / 32gb / 64gb. Querying the Codespaces machines API for this repo returns only `basicLinux32gb` (2/8gb/32gb) and `standardLinux32gb` (4/16gb/32gb), so the template values would make codespace creation fail. This PR uses 4 / 16gb / 32gb, matching the largest machine actually available. Note the storage ceiling is 32gb here regardless of the memory setting.

**Dependabot needed a follow-on fix.** A `docker` ecosystem entry pointed at `.devcontainer/` purely to bump the Dockerfile's base image. With the Dockerfile deleted it would have silently gone dead, so it is replaced with the `devcontainers` ecosystem, which reads `devcontainer.json` and updates the image *and* the feature versions. That matters more now that the feature versions are pinned.

**Stale Go version references.** `go.mod` requires 1.26.3 but several places still claimed 1.25. `copilot-setup-steps.yml` now resolves the version from `go.mod` the same way `ci.yml` already does, so it cannot drift again; the README badge, prerequisites, and `copilot-instructions.md` are corrected to 1.26.

Also checks in `.github/github-app.yml` (dev server / restore scripts and automation settings) so it is shared with the repo rather than living on one machine.

## Verification

Validated with an actual `devcontainer build`, not just config review. Inside the built image, running as the `vscode` user:

| Tool | Version |
| --- | --- |
| dotnet | 10.0.302 |
| node | v22.23.2 |
| python | 3.14.7 |
| uv | 0.12.3 |
| go | 1.26.3 |
| gh | 2.97.0 |
| pwsh | 7.6.2 |
| docker | 29.7.2 |
| aspire | 13.4.6 (`/usr/local/bin/aspire`) |

Two risks were cleared by that build: Python 3.14 has no prebuilt binary and the feature compiles it from source, which works but does lengthen a cold container build; and the Aspire installer logs a `/root/.aspire` path, but the v2 feature symlinks the CLI into `/usr/local/bin`, so `aspire run` works for the non-root `vscode` user.

Note there is no CI job that builds the dev container, so this validation was local and will not be repeated automatically on future changes.